### PR TITLE
Add `main` and `style` keys to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,7 @@
   },
   "devDependencies": {
     "gulp-sass": "^2.3.2"
-  }
+  },
+  "main": "src/Leaflet.LinearMeasurement.js",
+  "style": "sass/leaflet.scss"
 }


### PR DESCRIPTION
I wanted to use ur package, but I had to input whole path to JS and CSS files. This change will help others, co they can just use package name.
Example:

Before:
```js
/* JS */
import "leaflet-linear-measurement/src/Leaflet.LinearMeasurement.js";
```
```css
/* CSS/SCSS */
@import "~leaflet-linear-measurement/sass/Leaflet.LinearMeasurement.scss";
/* FYI: I had to put SCSS file there instead of CSS file, because after installation, there was SCSS file in `sass` directory, but no CSS file in `src` directory */
```

After:
```js
/* JS */
import "leaflet-linear-measurement";
```
```css
/* CSS/SCSS */
@import "~leaflet-linear-measurement";
```